### PR TITLE
fix: Rename _InjectAdditionalFiles target to avoid Uno.WinUI conflicts

### DIFF
--- a/src/Shiny.Mediator.SourceGenerators/SourceGenerators.targets
+++ b/src/Shiny.Mediator.SourceGenerators/SourceGenerators.targets
@@ -15,7 +15,7 @@
         <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="ContractPostfix" Visible="false" />
     </ItemGroup>
 
-    <Target Name="_InjectAdditionalFiles" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
+    <Target Name="_InjectMediatorHttpAdditionalFiles" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun;GenerateMSBuildEditorConfigFileCore">
         <ItemGroup>
             <AdditionalFiles Include="@(MediatorHttp)" 
                              Namespace="%(MediatorHttp.Namespace)" 


### PR DESCRIPTION
## Summary
This PR fixes an issue where the MediatorHttpRequestSourceGenerator doesn't work on `net9.0-desktop` targets in Uno projects.

## Problem
Uno.WinUI defines its own `_InjectAdditionalFiles` target in their build pipeline which overrides the one in SourceGenerators.targets. This prevents MediatorHttp items from being added as AdditionalFiles for the source generator when building for desktop targets.

The issue was discovered when the source generator worked fine for `net9.0-windows10.0.26100` but failed for `net9.0-desktop` targets.

## Solution
Renamed the target to `_InjectMediatorHttpAdditionalFiles` to avoid the naming conflict with Uno.WinUI's targets.

## Changes
- Renamed `_InjectAdditionalFiles` to `_InjectMediatorHttpAdditionalFiles` 
- Added `GenerateMSBuildEditorConfigFileCore` to BeforeTargets for better MSBuild compatibility across different versions

## Testing
- Tested locally in a production Uno project (Orderlyze.Sales)
- Confirmed that MediatorHttp items are now processed correctly on all targets:
  - ✅ net9.0-windows10.0.26100 (was already working)
  - ✅ net9.0-desktop (now fixed)
  - ✅ net9.0-browserwasm (was already working)

## Impact
- No breaking changes for existing projects
- The renamed target will work in all scenarios where the original worked
- Fixes compatibility with Uno Platform projects using multiple target frameworks

## Additional Context
This issue specifically affects Uno Platform projects that target desktop frameworks alongside Windows/WASM targets. The conflict occurs because Uno.WinUI's build targets take precedence over the mediator's targets when they share the same name.

🤖 Generated with [Claude Code](https://claude.ai/code)