### PR TITLE
feat: Add OpenTelemetry support for distributed tracing

### DIFF
--- a/Build.slnf
+++ b/Build.slnf
@@ -19,7 +19,8 @@
             "src\\Shiny.Mediator.Uno\\Shiny.Mediator.Uno.csproj",
             "src\\Shiny.Mediator.Testing\\Shiny.Mediator.Testing.csproj",
             "src\\Shiny.Mediator.Reflector\\Shiny.Mediator.Reflector.csproj",
-            "src\\Shiny.Mediator.Sentry\\Shiny.Mediator.Sentry.csproj"
+            "src\\Shiny.Mediator.Sentry\\Shiny.Mediator.Sentry.csproj",
+            "src\\Shiny.Mediator.OpenTelemetry\\Shiny.Mediator.OpenTelemetry.csproj"
         ]
     }
 }

--- a/ShinyMediator.slnx
+++ b/ShinyMediator.slnx
@@ -45,6 +45,7 @@
   <Project Path="src\Shiny.Mediator.Reflector\Shiny.Mediator.Reflector.csproj" Type="Classic C#" />
   <Project Path="src\Shiny.Mediator.Resilience\Shiny.Mediator.Resilience.csproj" />
   <Project Path="src\Shiny.Mediator.Sentry\Shiny.Mediator.Sentry.csproj" Type="Classic C#" />
+  <Project Path="src\Shiny.Mediator.OpenTelemetry\Shiny.Mediator.OpenTelemetry.csproj" Type="Classic C#" />
   <Project Path="src\Shiny.Mediator.Testing\Shiny.Mediator.Testing.csproj" Type="Classic C#" />
   <Project Path="src\Shiny.Mediator.Uno\Shiny.Mediator.Uno.csproj" />
   <Project Path="src\Shiny.Mediator\Shiny.Mediator.csproj" />

--- a/src/Shiny.Mediator.OpenTelemetry/MediatorExtensions.cs
+++ b/src/Shiny.Mediator.OpenTelemetry/MediatorExtensions.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.DependencyInjection;
+using Shiny.Mediator.OpenTelemetry;
+
+namespace Shiny.Mediator;
+
+public static class MediatorExtensions
+{
+    /// <summary>
+    /// Wires up OpenTelemetry to Mediator middleware - be sure to configure OpenTelemetry on your hosting provider
+    /// </summary>
+    /// <param name="configurator"></param>
+    /// <returns></returns>
+    public static ShinyMediatorBuilder UseOpenTelemetry(this ShinyMediatorBuilder configurator)
+    {
+        configurator.AddExceptionHandler<OpenTelemetryExceptionHandler>();
+        configurator.AddOpenEventMiddleware(typeof(OpenTelemetryEventMiddleware<>), ServiceLifetime.Singleton);
+        configurator.AddOpenCommandMiddleware(typeof(OpenTelemetryCommandMiddleware<>), ServiceLifetime.Singleton);
+        configurator.AddOpenRequestMiddleware(typeof(OpenTelemetryRequestMiddleware<,>), ServiceLifetime.Singleton);
+        configurator.AddOpenStreamMiddleware(typeof(OpenTelemetryStreamRequestMiddleware<,>), ServiceLifetime.Singleton);
+        return configurator;
+    }  
+}

--- a/src/Shiny.Mediator.OpenTelemetry/OpenTelemetryCommandMiddleware.cs
+++ b/src/Shiny.Mediator.OpenTelemetry/OpenTelemetryCommandMiddleware.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics;
+
+namespace Shiny.Mediator.OpenTelemetry;
+
+public class OpenTelemetryCommandMiddleware<TCommand> : ICommandMiddleware<TCommand> 
+    where TCommand : ICommand
+{
+    private static readonly ActivitySource ActivitySource = new("Shiny.Mediator", "1.0.0");
+
+    public async Task Process(
+        IMediatorContext context, 
+        CommandHandlerDelegate next, 
+        CancellationToken cancellationToken
+    )
+    {
+        using var activity = ActivitySource.StartActivity("mediator.command", ActivityKind.Internal);
+        
+        if (activity != null)
+        {
+            activity.SetTag("handler.type", context.MessageHandler?.GetType().FullName);
+            
+            foreach (var header in context.Headers)
+            {
+                activity.SetTag($"context.header.{header.Key}", header.Value);
+            }
+        }
+
+        try
+        {
+            await next().ConfigureAwait(false);
+            
+            activity?.SetStatus(ActivityStatusCode.Ok);
+        }
+        catch (Exception ex)
+        {
+            activity?.RecordException(ex);
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            throw;
+        }
+    }
+}

--- a/src/Shiny.Mediator.OpenTelemetry/OpenTelemetryEventMiddleware.cs
+++ b/src/Shiny.Mediator.OpenTelemetry/OpenTelemetryEventMiddleware.cs
@@ -1,0 +1,42 @@
+using System.Diagnostics;
+
+namespace Shiny.Mediator.OpenTelemetry;
+
+public class OpenTelemetryEventMiddleware<TEvent> : IEventMiddleware<TEvent> 
+    where TEvent : IEvent
+{
+    private static readonly ActivitySource ActivitySource = new("Shiny.Mediator", "1.0.0");
+
+    public async Task Process(
+        IMediatorContext context, 
+        EventHandlerDelegate next, 
+        CancellationToken cancellationToken
+    )
+    {
+        using var activity = ActivitySource.StartActivity("mediator.event", ActivityKind.Internal);
+        
+        if (activity != null)
+        {
+            activity.SetTag("handler.type", context.MessageHandler?.GetType().FullName);
+            activity.SetTag("event.type", typeof(TEvent).FullName);
+            
+            foreach (var header in context.Headers)
+            {
+                activity.SetTag($"context.header.{header.Key}", header.Value);
+            }
+        }
+
+        try
+        {
+            await next().ConfigureAwait(false);
+            
+            activity?.SetStatus(ActivityStatusCode.Ok);
+        }
+        catch (Exception ex)
+        {
+            activity?.RecordException(ex);
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            throw;
+        }
+    }
+}

--- a/src/Shiny.Mediator.OpenTelemetry/OpenTelemetryExceptionHandler.cs
+++ b/src/Shiny.Mediator.OpenTelemetry/OpenTelemetryExceptionHandler.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics;
+
+namespace Shiny.Mediator.OpenTelemetry;
+
+public class OpenTelemetryExceptionHandler : IExceptionHandler
+{
+    public Task<bool> Handle(IMediatorContext context, Exception exception)
+    {
+        var currentActivity = Activity.Current;
+        if (currentActivity != null)
+        {
+            currentActivity.RecordException(exception);
+            currentActivity.SetStatus(ActivityStatusCode.Error, exception.Message);
+            
+            currentActivity.SetTag("exception.type", exception.GetType().FullName);
+            currentActivity.SetTag("exception.message", exception.Message);
+            
+            if (!string.IsNullOrEmpty(exception.StackTrace))
+            {
+                currentActivity.SetTag("exception.stacktrace", exception.StackTrace);
+            }
+        }
+        
+        return Task.FromResult(false);
+    }
+}

--- a/src/Shiny.Mediator.OpenTelemetry/OpenTelemetryRequestMiddleware.cs
+++ b/src/Shiny.Mediator.OpenTelemetry/OpenTelemetryRequestMiddleware.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics;
+using Shiny.Mediator.Infrastructure;
+
+namespace Shiny.Mediator.OpenTelemetry;
+
+public class OpenTelemetryRequestMiddleware<TRequest, TResult> : IRequestMiddleware<TRequest, TResult> 
+    where TRequest : IRequest<TResult>
+{
+    private static readonly ActivitySource ActivitySource = new("Shiny.Mediator", "1.0.0");
+    private readonly IContractKeyProvider _contractKeyProvider;
+
+    public OpenTelemetryRequestMiddleware(IContractKeyProvider contractKeyProvider)
+    {
+        _contractKeyProvider = contractKeyProvider;
+    }
+
+    public async Task<TResult> Process(
+        IMediatorContext context, 
+        RequestHandlerDelegate<TResult> next, 
+        CancellationToken cancellationToken
+    )
+    {
+        using var activity = ActivitySource.StartActivity("mediator.request", ActivityKind.Internal);
+        
+        if (activity != null)
+        {
+            activity.SetTag("handler.type", context.MessageHandler?.GetType().FullName);
+            
+            var requestKey = _contractKeyProvider.GetContractKey(context.Message!);
+            activity.SetTag("request.key", requestKey);
+            
+            foreach (var header in context.Headers)
+            {
+                activity.SetTag($"context.header.{header.Key}", header.Value);
+            }
+        }
+
+        try
+        {
+            var result = await next().ConfigureAwait(false);
+            
+            activity?.SetStatus(ActivityStatusCode.Ok);
+            
+            return result;
+        }
+        catch (Exception ex)
+        {
+            activity?.RecordException(ex);
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            throw;
+        }
+    }
+}

--- a/src/Shiny.Mediator.OpenTelemetry/OpenTelemetryStreamRequestMiddleware.cs
+++ b/src/Shiny.Mediator.OpenTelemetry/OpenTelemetryStreamRequestMiddleware.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics;
+using Shiny.Mediator.Infrastructure;
+
+namespace Shiny.Mediator.OpenTelemetry;
+
+public class OpenTelemetryStreamRequestMiddleware<TRequest, TResult> : IStreamRequestMiddleware<TRequest, TResult> 
+    where TRequest : IStreamRequest<TResult>
+{
+    private static readonly ActivitySource ActivitySource = new("Shiny.Mediator", "1.0.0");
+    private readonly IContractKeyProvider _contractKeyProvider;
+
+    public OpenTelemetryStreamRequestMiddleware(IContractKeyProvider contractKeyProvider)
+    {
+        _contractKeyProvider = contractKeyProvider;
+    }
+
+    public async IAsyncEnumerable<TResult> Process(
+        IMediatorContext context, 
+        StreamRequestHandlerDelegate<TResult> next,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken
+    )
+    {
+        using var activity = ActivitySource.StartActivity("mediator.stream", ActivityKind.Internal);
+        
+        if (activity != null)
+        {
+            activity.SetTag("handler.type", context.MessageHandler?.GetType().FullName);
+            
+            var requestKey = _contractKeyProvider.GetContractKey(context.Message!);
+            activity.SetTag("request.key", requestKey);
+            
+            foreach (var header in context.Headers)
+            {
+                activity.SetTag($"context.header.{header.Key}", header.Value);
+            }
+        }
+
+        var itemCount = 0;
+        Activity? itemActivity = null;
+
+        try
+        {
+            var nxt = next();
+            await foreach (var item in nxt.WithCancellation(cancellationToken))
+            {
+                itemActivity?.Dispose();
+                itemActivity = ActivitySource.StartActivity("mediator.stream.item", ActivityKind.Internal, activity?.Context ?? default);
+                itemActivity?.SetTag("item.index", itemCount++);
+                
+                yield return item;
+            }
+            
+            activity?.SetTag("stream.item_count", itemCount);
+            activity?.SetStatus(ActivityStatusCode.Ok);
+        }
+        catch (Exception ex)
+        {
+            activity?.RecordException(ex);
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            throw;
+        }
+        finally
+        {
+            itemActivity?.Dispose();
+        }
+    }
+}

--- a/src/Shiny.Mediator.OpenTelemetry/Shiny.Mediator.OpenTelemetry.csproj
+++ b/src/Shiny.Mediator.OpenTelemetry/Shiny.Mediator.OpenTelemetry.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Shiny.Mediator\Shiny.Mediator.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="OpenTelemetry.Api"/>
+        <PackageReference Include="System.Diagnostics.DiagnosticSource"/>
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- Added new `Shiny.Mediator.OpenTelemetry` project for distributed tracing support
- Implemented middleware for all mediator patterns (Request, Command, Event, StreamRequest)
- Added exception handler for proper error recording in traces

## Implementation Details

This PR adds OpenTelemetry support to Shiny.Mediator, following the same pattern as the existing Sentry integration:

### New Project: `Shiny.Mediator.OpenTelemetry`
- Uses `System.Diagnostics.ActivitySource` for OpenTelemetry-compatible tracing
- Creates appropriate spans for each mediator operation
- Records context information as Activity tags
- Handles exceptions with proper status codes and error recording

### Middleware Classes (in separate files):
- `OpenTelemetryRequestMiddleware<TRequest, TResult>` - Traces request/response operations
- `OpenTelemetryCommandMiddleware<TCommand>` - Traces command operations  
- `OpenTelemetryEventMiddleware<TEvent>` - Traces event handling
- `OpenTelemetryStreamRequestMiddleware<TRequest, TResult>` - Traces streaming operations with per-item spans

### Additional Components:
- `OpenTelemetryExceptionHandler` - Records exceptions to current Activity
- `MediatorExtensions.UseOpenTelemetry()` - Simple registration method

### Usage:
```csharp
services.AddShinyMediator(cfg =>
{
    cfg.UseOpenTelemetry();
});

// Configure OpenTelemetry
services.AddOpenTelemetry()
    .WithTracing(tracerProviderBuilder =>
    {
        tracerProviderBuilder
            .AddSource("Shiny.Mediator")
            .AddOtlpExporter();
    });
```

## Test plan
- [ ] Build and unit tests pass
- [ ] Manual testing with sample application
- [ ] Verify spans are properly created in OpenTelemetry collector
- [ ] Test exception recording
- [ ] Verify streaming request span hierarchy

🤖 Generated with [Claude Code](https://claude.ai/code)