### PR TITLE
Add support for plain string responses in HTTP request handler

### DIFF
--- a/src/Shiny.Mediator/Http/BaseHttpRequestHandler.cs
+++ b/src/Shiny.Mediator/Http/BaseHttpRequestHandler.cs
@@ -160,13 +160,19 @@ public abstract class BaseHttpRequestHandler
             {
                 finalResult = (TResult)(object)response;
             }
+            else if (typeof(TResult) == typeof(string))
+            {
+                // Handle plain string responses (not JSON)
+                var stringContent = await response.Content.ReadAsStringAsync(cts.Token).ConfigureAwait(false);
+                finalResult = (TResult)(object)stringContent;
+            }
             else
             {
                 var stringResult = await response
                     .Content
                     .ReadAsStringAsync(cts.Token)
                     .ConfigureAwait(false);
-    
+
                 finalResult = this.services.Serializer.Deserialize<TResult>(stringResult)!;
             }
         }


### PR DESCRIPTION
## Summary
- Added handling for plain string responses in `BaseHttpRequestHandler.Send<TResult>` method that don't require JSON deserialization
- When `TResult` is of type `string`, the response content is now read directly as a string instead of attempting JSON deserialization

## Changes
This PR adds an additional condition in the `Send<TResult>` method to check if `typeof(TResult) == typeof(string)` before falling back to JSON deserialization. This prevents deserialization errors when the API endpoint returns plain text responses.

The change follows the existing pattern for handling `HttpResponseMessage` responses and maintains the same coding style.

## Test plan
- [ ] Test with endpoints that return plain text/string responses
- [ ] Verify that JSON responses still work correctly
- [ ] Verify that HttpResponseMessage handling still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)